### PR TITLE
feat: add Invoke function via function URL Task as md

### DIFF
--- a/docs/aws/lambda-url-invoking.md
+++ b/docs/aws/lambda-url-invoking.md
@@ -1,8 +1,9 @@
 # Lambda - URL Invoking
 
 ## #week_ten - Invoke function via function URL
+<br>
 
-**_duration: 1 week_**
+**_duration: 1 week_**<br><br>
 
 ForgTech company wanna test your ability to type down a clean code by Deploying the structure of resources. This will help you to build a
 good reputation.
@@ -21,13 +22,16 @@ command, FrogTech Developers will be using curl command to trigger & pass values
 FrogTech is required to use high-level HCL language techniques, by Crafting a subnet resources module, Package your library
 dependencies as a ZIP file, and using it in the lambda layer instead.
 
+<br>
+<br>
+
 Use IaC Terraform to build all resources and consider the below requirements specifications.
 
 1. Resources must be created at the us-east-1 region.
 2. Resources must have common tags combination as below:
 3. Common tags:
-    a. Key: “Environment”, Value: “terraformChamps”
-    b. Key: “Owner”, Value: <“Your_first_name“>
+    - Key: “Environment”, Value: “terraformChamps”
+    - Key: “Owner”, Value: <“Your_first_name“>
 
 **Bouns**
 

--- a/docs/aws/lambda-url-invoking.md
+++ b/docs/aws/lambda-url-invoking.md
@@ -37,6 +37,7 @@ Use IaC Terraform to build all resources and consider the below requirements spe
 
 1. Build an Architecture diagram of the deployment resources.
 2. Build your own blog and create an article explaining lambda tricks, instead of using documents.
+<br>
 
 
 ## References:

--- a/docs/aws/lambda-url-invoking.md
+++ b/docs/aws/lambda-url-invoking.md
@@ -1,0 +1,39 @@
+# Lambda - URL Invoking
+
+## #week_ten - Invoke function via function URL
+
+**_duration: 1 week_**
+
+ForgTech company wanna test your ability to type down a clean code by Deploying the structure of resources. This will help you to build a
+good reputation.
+FrogTech intends to automate some processes and configurations on EFS mounted Disk By internal scripts created by Developers.
+You’re requested to use lambda function that mounts The EFS disk to submit and configure the passed parameters to the function event.
+The Developers will provide directory names as event values and your mission to create directories based on passed values.
+_Hence, the developers will pass values to the function event and the function will Create directories into the mounted EFS with the passed
+event values._
+Next, You should test and provide FrogTech developers with the function URL in order to include it into their scripts using the curl
+command, FrogTech Developers will be using curl command to trigger & pass values to the function.
+FrogTech is required to use high-level HCL language techniques, by Crafting a subnet resources module, Package your library
+dependencies as a ZIP file, and using it in the lambda layer instead.
+
+Use IaC Terraform to build all resources and consider the below requirements specifications.
+
+1. Resources must be created at the us-east-1 region.
+2. Resources must have common tags combination as below:
+3. Common tags:
+    a. Key: “Environment”, Value: “terraformChamps”
+    b. Key: “Owner”, Value: <“Your_first_name“>
+
+**Bouns**
+
+1. Build an Architecture diagram of the deployment resources.
+2. Build your own blog and create an article explaining lambda tricks, instead of using documents.
+
+
+## References:
+
+- [\[AWS\] Lambda - URL Invoking + Terraform Project 11](https://mohamed-eleraky.hashnode.dev/aws-lambda-url-invoking-terraform-project-11)
+- https://github.com/Mohamed-Eleraki/terraform/tree/main/AWS_Demo/19-lambda-config_EFS_storage-URL_invokation Can't find link
+- https://github.com/Mohamed-Eleraki/terraform/tree/main/AWS_Demo/31-Create_Modules Can't find link
+- [Create your blog on hashnode](https://hashnode.com/)
+- [Create your blog on DEV](https://dev.to/)

--- a/docs/aws/lambda-url-invoking.md
+++ b/docs/aws/lambda-url-invoking.md
@@ -6,13 +6,18 @@
 
 ForgTech company wanna test your ability to type down a clean code by Deploying the structure of resources. This will help you to build a
 good reputation.
+
 FrogTech intends to automate some processes and configurations on EFS mounted Disk By internal scripts created by Developers.
+
 You’re requested to use lambda function that mounts The EFS disk to submit and configure the passed parameters to the function event.
 The Developers will provide directory names as event values and your mission to create directories based on passed values.
+
 _Hence, the developers will pass values to the function event and the function will Create directories into the mounted EFS with the passed
 event values._
+
 Next, You should test and provide FrogTech developers with the function URL in order to include it into their scripts using the curl
 command, FrogTech Developers will be using curl command to trigger & pass values to the function.
+
 FrogTech is required to use high-level HCL language techniques, by Crafting a subnet resources module, Package your library
 dependencies as a ZIP file, and using it in the lambda layer instead.
 
@@ -32,8 +37,6 @@ Use IaC Terraform to build all resources and consider the below requirements spe
 
 ## References:
 
-- [\[AWS\] Lambda - URL Invoking + Terraform Project 11](https://mohamed-eleraky.hashnode.dev/aws-lambda-url-invoking-terraform-project-11)
-- https://github.com/Mohamed-Eleraki/terraform/tree/main/AWS_Demo/19-lambda-config_EFS_storage-URL_invokation Can't find link
-- https://github.com/Mohamed-Eleraki/terraform/tree/main/AWS_Demo/31-Create_Modules Can't find link
+- [\[AWS\] Lambda - URL Invoking + Terraform Project 11](https://eraki.hashnode.dev/aws-lambda-url-invoking-terraform-project-11)
 - [Create your blog on hashnode](https://hashnode.com/)
 - [Create your blog on DEV](https://dev.to/)


### PR DESCRIPTION
Invoke function via function URL 

This links in the task isnt working:

- [\[AWS\] Lambda - URL Invoking + Terraform Project 11](https://mohamed-eleraky.hashnode.dev/aws-lambda-url-invoking-terraform-project-11)
- https://github.com/Mohamed-Eleraki/terraform/tree/main/AWS_Demo/19-lambda-config_EFS_storage-URL_invokation Can't find link
- https://github.com/Mohamed-Eleraki/terraform/tree/main/AWS_Demo/31-Create_Modules Can't find link